### PR TITLE
float128 -> longdouble

### DIFF
--- a/pyvisfile/xdmf/__init__.py
+++ b/pyvisfile/xdmf/__init__.py
@@ -310,7 +310,7 @@ class DataItemNumberType(enum.Enum):
             return DataItemNumberType.Int
         elif dtype.type in (np.uint8, np.uint16, np.uint32, np.uint64, np.uint):
             return DataItemNumberType.UInt
-        elif dtype.type in (np.float16, np.float32, np.float64, np.float128):
+        elif dtype.type in (np.float16, np.float32, np.float64, np.longdouble):
             return DataItemNumberType.Float
         else:
             raise ValueError(f"unsupported dtype: '{dtype}'")

--- a/pyvisfile/xdmf/__init__.py
+++ b/pyvisfile/xdmf/__init__.py
@@ -306,11 +306,11 @@ class DataItemNumberType(enum.Enum):
 
     @staticmethod
     def from_dtype(dtype: np.dtype) -> "DataItemNumberType":
-        if dtype.type in (np.int8, np.int16, np.int32, np.int64, np.int):
+        if dtype.kind == "i":
             return DataItemNumberType.Int
-        elif dtype.type in (np.uint8, np.uint16, np.uint32, np.uint64, np.uint):
+        elif dtype.kind == "u":
             return DataItemNumberType.UInt
-        elif dtype.type in (np.float16, np.float32, np.float64, np.longdouble):
+        elif dtype.kind == "f":
             return DataItemNumberType.Float
         else:
             raise ValueError(f"unsupported dtype: '{dtype}'")


### PR DESCRIPTION
Background: Not all Python/numpy builds have `np.float128` (_cough_ Windows/Mac?):
- https://github.com/winpython/winpython/issues/613
- https://github.com/numpy/numpy/issues/10288

Prevents errors of the form:
```
Traceback (most recent call last):
  File "/Users/mdiener/Work/emirge_lazy/meshmode/test/test_visualization.py", line 180, in test_visualizers
    vis.write_xdmf_file(f"{basename}.xmf", names_and_fields, overwrite=True)
  File "/Users/mdiener/Work/emirge_lazy/meshmode/meshmode/discretization/visualization.py", line 958, in write_xdmf_file
    gnodes = DataArray.from_dataset(dset)
  File "/Users/mdiener/Work/emirge_lazy/miniforge3/envs/ceesd_lazy/lib/python3.8/site-packages/pyvisfile/xdmf/__init__.py", line 981, in from_dataset
    item = _data_item_from_numpy(dset,
  File "/Users/mdiener/Work/emirge_lazy/miniforge3/envs/ceesd_lazy/lib/python3.8/site-packages/pyvisfile/xdmf/__init__.py", line 474, in _data_item_from_numpy
    ntype=DataItemNumberType.from_dtype(ary.dtype),
  File "/Users/mdiener/Work/emirge_lazy/miniforge3/envs/ceesd_lazy/lib/python3.8/site-packages/pyvisfile/xdmf/__init__.py", line 313, in from_dtype
    elif dtype.type in (np.float16, np.float32, np.float64, np.float128):
  File "/Users/mdiener/Work/emirge_lazy/miniforge3/envs/ceesd_lazy/lib/python3.8/site-packages/numpy/__init__.py", line 303, in __getattr__
    raise AttributeError("module {!r} has no attribute "
AttributeError: module 'numpy' has no attribute 'float128'
```

cc: @alexfikl 