### PR TITLE
Bump examples CI Python version to 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
         runs-on: ${{ matrix.os }}
         strategy:
             matrix:
-                python-version: [3.6, 3.x]
+                python-version: [3.7, 3.x]
                 os: [ubuntu-latest, macos-latest]
         steps:
         -   uses: actions/checkout@v2


### PR DESCRIPTION
Github has discontinued 3.6 support on macOS11.
See https://github.com/actions/virtual-environments/issues/4060