### PR TITLE
Allow VTK `UnstructuredGrid` to be empty

### DIFF
--- a/pyvisfile/vtk/__init__.py
+++ b/pyvisfile/vtk/__init__.py
@@ -477,9 +477,12 @@ class UnstructuredGrid:
         except Exception:
             self.cell_count = len(cell_types)
 
-            offsets = np.cumsum(
-                    np.vectorize(CELL_NODE_COUNT.get)(cell_types),
-                    dtype=cells.dtype)
+            if self.cell_count > 0:
+                offsets = np.cumsum(
+                        np.vectorize(CELL_NODE_COUNT.get)(cell_types),
+                        dtype=cells.dtype)
+            else:
+                offsets = np.empty((0,), dtype=cells.dtype)
 
             self.cell_connectivity = DataArray("connectivity", cells)
             self.cell_offsets = DataArray("offsets", offsets)

--- a/test/test_vtk.py
+++ b/test/test_vtk.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 from pyvisfile.vtk import (
     UnstructuredGrid, DataArray,
     AppendedDataXMLGenerator,
@@ -7,15 +8,15 @@ from pyvisfile.vtk import (
 from pyvisfile.vtk import write_structured_grid
 
 
-def test_vtk_unstructured_points():
-    n = 5000
+@pytest.mark.parametrize("n", [5000, 0])
+def test_vtk_unstructured_points(n):
     points = np.random.randn(n, 3)
 
     data = [
             ("p", np.random.randn(n)),
             ("vel", np.random.randn(3, n)),
     ]
-    file_name = "points.vtu"
+    file_name = f"points_{n}.vtu"
     compressor = None
 
     grid = UnstructuredGrid(


### PR DESCRIPTION
This change prevents errors like

```
    grid = UnstructuredGrid(
  File "pyvisfile/vtk/__init__.py", line 481, in __init__
    np.vectorize(CELL_NODE_COUNT.get)(cell_types),
  File "python3.9/site-packages/numpy/lib/function_base.py", line 2304, in __call__
    return self._vectorize_call(func=func, args=vargs)
  File "python3.9/site-packages/numpy/lib/function_base.py", line 2382, in _vectorize_call
    ufunc, otypes = self._get_ufunc_and_otypes(func=func, args=args)
  File "python3.9/site-packages/numpy/lib/function_base.py", line 2338, in _get_ufunc_and_otypes
    raise ValueError('cannot call `vectorize` on size 0 inputs '
ValueError: cannot call `vectorize` on size 0 inputs unless `otypes` is set
```

when the number of cells is 0.