### PR TITLE
vtk: add typing to entire module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,9 @@ setuptools.pth
 distribute-*.tar.gz
 distribute-*.egg
 *.vtu
+*.pvtu
 *.vts
+*.pvts
 *.xmf
 .eggs
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -4,7 +4,7 @@
 # You can set these variables from the command line, and also
 # from the environment for the first two.
 SPHINXOPTS    ?=
-SPHINXBUILD   ?= sphinx-build
+SPHINXBUILD   ?= python $(shell which sphinx-build)
 SOURCEDIR     = "."
 BUILDDIR      = _build
 

--- a/doc/vtk.rst
+++ b/doc/vtk.rst
@@ -4,6 +4,7 @@ Usage Reference for :mod:`pyvisfile.vtk`
 .. automodule:: pyvisfile.vtk
 .. moduleauthor:: Andreas Kloeckner <inform@tiker.net>
 
+.. automodule:: pyvisfile.vtk.vtk_ordering
 
 Examples
 --------

--- a/examples/vtk-structured-2d-plain.py
+++ b/examples/vtk-structured-2d-plain.py
@@ -2,16 +2,16 @@
 
 import numpy as np
 
-
-n = 50
-x, y = np.meshgrid(np.linspace(-1, 1, n),
-np.linspace(-1, 1, n))
-
-u = np.exp(-50 * (x**2 + y**2))
-
 from pyvisfile.vtk import write_structured_grid
 
 
+n = 50
+x, y = np.meshgrid(np.linspace(-1, 1, n), np.linspace(-1, 1, n))
+
+u = np.exp(-50 * (x**2 + y**2))
+
 mesh = np.rollaxis(np.dstack((x, y)), 2)
-write_structured_grid("test.vts", mesh,
-        point_data=[("u", u[np.newaxis, :, :])])
+write_structured_grid(
+    "test.vts",
+    mesh,
+    point_data=[("u", u[np.newaxis, :, :])])

--- a/pyvisfile/vtk/__init__.py
+++ b/pyvisfile/vtk/__init__.py
@@ -22,6 +22,11 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
+import pathlib
+from abc import ABC, abstractmethod
+from typing import (
+    Any, ByteString, ClassVar, List, Optional, TextIO, Tuple, Union, cast)
+
 import numpy as np
 
 
@@ -66,24 +71,47 @@ Element types
 .. data:: VTK_LAGRANGE_HEXAHEDRON
 .. data:: VTK_LAGRANGE_WEDGE
 
-Building blocks
----------------
-
-.. autoclass:: DataArray
-.. autoclass:: UnstructuredGrid
-.. autoclass:: StructuredGrid
-
 XML elements
 ^^^^^^^^^^^^^^
 
+.. autoclass:: XMLElementBase
 .. autoclass:: XMLElement
+    :show-inheritance:
+.. autoclass:: XMLRoot
+    :show-inheritance:
+
+Binary encoders
+^^^^^^^^^^^^^^^
+
+.. autoclass:: EncodedBuffer
+.. autoclass:: BinaryEncodedBuffer
+    :show-inheritance:
+.. autoclass:: Base64EncodedBuffer
+    :show-inheritance:
+.. autoclass:: Base64ZLibEncodedBuffer
+    :show-inheritance:
+
+Building blocks
+---------------
+
+.. autoclass:: Visitable
+.. autoclass:: DataArray
+    :show-inheritance:
+.. autoclass:: UnstructuredGrid
+    :show-inheritance:
+.. autoclass:: StructuredGrid
+    :show-inheritance:
 
 XML generators
 ^^^^^^^^^^^^^^
 
+.. autoclass:: XMLGenerator
 .. autoclass:: InlineXMLGenerator
+    :show-inheritance:
 .. autoclass:: AppendedDataXMLGenerator
+    :show-inheritance:
 .. autoclass:: ParallelXMLGenerator
+    :show-inheritance:
 
 Convenience functions
 ---------------------
@@ -197,63 +225,97 @@ VF_LIST_OF_VECTORS = 1
 # {{{ xml
 
 # Ah, the joys of home-baked non-compliant XML goodness.
+
+Child = Union[str, "XMLElement"]
+
+
 class XMLElementBase:
-    def __init__(self):
-        self.children = []
+    """Base type for XML elements.
 
-    def copy(self, new_children=None):
-        result = self.__class__(self.tag, self.attributes)
-        if new_children is not None:
-            result.children = new_children
-        else:
-            result.children = self.children
-        return result
+    .. attribute:: children
+        :type: List[Union[str, XMLElement]]
 
-    def add_child(self, child):
+    .. automethod:: add_child
+    """
+
+    def __init__(self) -> None:
+        self.children: List[Child] = []
+
+    def add_child(self, child: Child) -> None:
+        """Append a new child to the current element."""
         self.children.append(child)
 
 
 class XMLElement(XMLElementBase):
     """
+    .. automethod:: __init__
+    .. automethod:: copy
     .. automethod:: write
     """
 
-    def __init__(self, tag, **attributes):
-        XMLElementBase.__init__(self)
+    def __init__(self, tag: str, **attributes: Any) -> None:
+        super().__init__()
         self.tag = tag
         self.attributes = attributes
 
-    def write(self, file):
+    def copy(self, children: Optional[List[Child]] = None) -> "XMLElement":
+        """Make a copy of the element with new children."""
+        if children is None:
+            children = self.children
+
+        result = type(self)(self.tag, **self.attributes)
+        for child in children:
+            result.add_child(child)
+
+        return result
+
+    def write(self, fd: TextIO) -> None:
+        """Write the current element and all of its children to a file.
+
+        :arg fd: a file descriptor or another object exposing the required methods.
+        """
         attr_string = "".join(
                 f' {key}="{value}"'
                 for key, value in self.attributes.items())
+
         if self.children:
-            file.write(f"<{self.tag}{attr_string}>\n")
+            fd.write(f"<{self.tag}{attr_string}>\n")
             for child in self.children:
                 if isinstance(child, XMLElement):
-                    child.write(file)
+                    child.write(fd)
                 else:
                     # likely a string instance, write it directly
-                    file.write(child)
-            file.write(f"</{self.tag}>\n")
+                    fd.write(child)
+            fd.write(f"</{self.tag}>\n")
         else:
-            file.write(f"<{self.tag}{attr_string}/>\n")
+            # NOTE: this one has an extra /> at the end
+            fd.write(f"<{self.tag}{attr_string}/>\n")
 
 
 class XMLRoot(XMLElementBase):
-    def __init__(self, child=None):
-        XMLElementBase.__init__(self)
+    """
+    .. automethod:: __init__
+    .. automethod:: write
+    """
+
+    def __init__(self, child: Optional[Child] = None) -> None:
+        super().__init__()
         if child:
             self.add_child(child)
 
-    def write(self, file):
-        file.write('<?xml version="1.0"?>\n')
+    def write(self, fd: TextIO) -> None:
+        """Write the current root and all of its children to a file.
+
+        :arg fd: a file descriptor or another object exposing the required methods.
+        """
+        fd.write('<?xml version="1.0"?>\n')
+
         for child in self.children:
             if isinstance(child, XMLElement):
-                child.write(file)
+                child.write(fd)
             else:
                 # likely a string instance, write it directly
-                file.write(child)
+                fd.write(child)
 
 # }}}
 
@@ -263,102 +325,119 @@ class XMLRoot(XMLElementBase):
 _U32CHAR = np.dtype(np.uint32).char
 
 
-class EncodedBuffer:
-    def encoder(self):
-        """Return an identifier for the binary encoding used."""
-        raise NotImplementedError
+class EncodedBuffer(ABC):
+    """An interface for binary buffers for XML data (inline and appended).
 
-    def compressor(self):
-        """Return an identifier for the compressor used, or None."""
-        raise NotImplementedError
+    .. automethod:: encoder
+    .. automethod:: compressor
+    .. automethod:: raw_buffer
+    .. automethod:: add_to_xml_element
+    """
 
-    def raw_buffer(self):
-        """Reobtain the raw buffer string object that was used to
-        construct this encoded buffer."""
+    @abstractmethod
+    def encoder(self) -> str:
+        """An identifier for the binary encoding used."""
 
-        raise NotImplementedError
+    @abstractmethod
+    def compressor(self) -> Optional[str]:
+        """An identifier for the compressor used or *None*."""
 
-    def add_to_xml_element(self, xml_element):
-        """Add encoded buffer to the given *xml_element*
-        Return total size of encoded buffer in bytes."""
+    @abstractmethod
+    def raw_buffer(self) -> ByteString:
+        """The raw buffer object that was used to construct this encoded buffer."""
 
-        raise NotImplementedError
+    @abstractmethod
+    def add_to_xml_element(self, xml_element: XMLElement) -> int:
+        """Add encoded buffer to the given *xml_element*.
+
+        :returns: total size of encoded buffer in bytes.
+        """
 
 
-class BinaryEncodedBuffer:
-    def __init__(self, buffer):
+class BinaryEncodedBuffer(EncodedBuffer):
+    """An encoded buffer that uses raw uncompressed binary data.
+
+    .. automethod:: __init__
+    """
+
+    def __init__(self, buffer: ByteString) -> None:
         self.buffer = buffer
 
-    def encoder(self):
+    def encoder(self) -> str:
         return "binary"
 
-    def compressor(self):
+    def compressor(self) -> Optional[str]:
         return None
 
-    def raw_buffer(self):
+    def raw_buffer(self) -> ByteString:
         return self.buffer
 
-    def add_to_xml_element(self, xml_element):
+    def add_to_xml_element(self, xml_element: XMLElement) -> int:
         raise NotImplementedError
 
 
-class Base64EncodedBuffer:
-    def __init__(self, buffer):
+class Base64EncodedBuffer(EncodedBuffer):
+    """An encoded buffer that uses :mod:`base64` data.
+
+    .. automethod:: __init__
+    """
+
+    def __init__(self, buffer: memoryview) -> None:
         from base64 import b64encode
         from struct import pack
+
         length = buffer.nbytes
-        self.b64header = b64encode(
-                pack(_U32CHAR, length)).decode()
+        self.b64header = b64encode(pack(_U32CHAR, length)).decode()
         self.b64data = b64encode(buffer).decode()
 
-    def encoder(self):
+    def encoder(self) -> str:
         return "base64"
 
-    def compressor(self):
+    def compressor(self) -> Optional[str]:
         return None
 
-    def raw_buffer(self):
+    def raw_buffer(self) -> ByteString:
         from base64 import b64decode
         return b64decode(self.b64data)
 
-    def add_to_xml_element(self, xml_element):
-        """Add encoded buffer to the given *xml_element*.
-        Return total size of encoded buffer in bytes."""
-
+    def add_to_xml_element(self, xml_element: XMLElement) -> int:
         xml_element.add_child(self.b64header)
         xml_element.add_child(self.b64data)
 
         return len(self.b64header) + len(self.b64data)
 
 
-class Base64ZLibEncodedBuffer:
-    def __init__(self, buffer):
+class Base64ZLibEncodedBuffer(EncodedBuffer):
+    """An encoded buffer that uses :mod:`base64` and :mod:`zlib` compression.
+
+    .. automethod:: __init__
+    """
+
+    def __init__(self, buffer: ByteString) -> None:
         from base64 import b64encode
         from struct import pack
         from zlib import compress
+
         comp_buffer = compress(buffer)
         comp_header = [1, len(buffer), len(buffer), len(comp_buffer)]
-        self.b64header = b64encode(
-                pack(_U32CHAR*len(comp_header), *comp_header))
+
+        self.b64header = b64encode(pack(_U32CHAR*len(comp_header), *comp_header))
         self.b64data = b64encode(comp_buffer)
 
-    def encoder(self):
+    def encoder(self) -> str:
         return "base64"
 
-    def compressor(self):
+    def compressor(self) -> Optional[str]:
         return "zlib"
 
-    def raw_buffer(self):
+    def raw_buffer(self) -> ByteString:
         from base64 import b64decode
         from zlib import decompress
         return decompress(b64decode(self.b64data))
 
-    def add_to_xml_element(self, xml_element):
-        """Add encoded buffer to the given *xml_element*.
-        Return total size of encoded buffer in bytes."""
-
-        xml_element.add_child(self.b64header)
-        xml_element.add_child(self.b64data)
+    def add_to_xml_element(self, xml_element: XMLElement) -> int:
+        xml_element.add_child(self.b64header.decode())
+        xml_element.add_child(self.b64data.decode())
 
         return len(self.b64header) + len(self.b64data)
 
@@ -367,26 +446,79 @@ class Base64ZLibEncodedBuffer:
 
 # {{{ data array
 
-class DataArray:
-    def __init__(self, name, container, vector_padding=3,
-            vector_format=VF_LIST_OF_COMPONENTS, components=None):
+class Visitable:
+    """A generic class for objects that can be mapped to XML elements.
+
+    .. autoattribute:: generator_method
+    .. automethod:: invoke_visitor
+    """
+
+    #: Name of the method called in :meth:`invoke_visitor`.
+    generator_method: ClassVar[str]
+
+    def invoke_visitor(self, visitor: "XMLGenerator") -> XMLElement:
+        """Visit the current object with the given *visitor* and generate the
+        corresponding XML element.
+        """
+        method = getattr(visitor, self.generator_method, None)
+        if method is None:
+            raise TypeError(
+                f"{type(visitor).__name__} does not support {type(self)}"
+                )
+
+        return cast(XMLElement, method(self))
+
+
+class DataArray(Visitable):
+    """A representation of a generic VTK DataArray.
+
+    The storage format (inline or appended) is determined by the
+    :class:`XMLGenerator` at writing time.
+
+    .. automethod:: __init__
+    .. automethod:: get_encoded_buffer
+    .. automethod:: encode
+    """
+
+    generator_method = "gen_data_array"
+
+    def __init__(self,
+                 name: str,
+                 container: Any,
+                 vector_padding: int = 3,
+                 vector_format: int = VF_LIST_OF_COMPONENTS,
+                 components: Optional[int] = None) -> None:
+        """
+        :arg name: name of the data array.
+        :arg container: a :class:`numpy.ndarray` or another :class:`DataArray`.
+        :arg vector_padding: pad any :class:`~numpy.ndarray` with additional
+            zeros given by this variable.
+        :arg vector_format: :data:`VF_LIST_OF_COMPONENTS` or
+            :data:`VF_LIST_OF_VECTORS`.
+        :arg components: number of components in the container (not used).
+        """
         self.name = name
 
         if isinstance(container, DataArray):
-            self.type = container.type
-            self.components = container.components
-            self.encoded_buffer = container.encoded_buffer
+            self.type: Optional[str] = container.type
+            self.components: int = container.components
+            self.encoded_buffer: EncodedBuffer = container.encoded_buffer
             return
-
-        if not isinstance(container, np.ndarray):
+        elif isinstance(container, np.ndarray):
+            # NOTE: handled below
+            pass
+        else:
             raise ValueError(
-                f"cannot convert object of type '{type(container)}' to DataArray")
+                f"Cannot convert object of type '{type(container)}' to DataArray")
+
+        if vector_format not in (VF_LIST_OF_COMPONENTS, VF_LIST_OF_VECTORS):
+            raise ValueError(f"Unknown vector format: {vector_format}")
 
         if container.dtype.char == "O":
             for subvec in container:
                 if not isinstance(subvec, np.ndarray):
                     raise TypeError(
-                            f"expected numpy array, got '{type(subvec)}' instead")
+                            f"Expected a numpy array, got '{type(subvec)}' instead")
 
             container = np.array(list(container))
             assert container.dtype.char != "O"
@@ -414,7 +546,7 @@ class DataArray:
 
         self.type = NUMPY_TO_VTK_TYPES.get(container.dtype.type, None)
         if self.type is None:
-            raise TypeError(f"unsupported vector type: '{container.dtype}'")
+            raise TypeError(f"Unsupported array dtype: '{container.dtype}'")
 
         if not container.flags.c_contiguous:
             container = container.copy()
@@ -422,7 +554,14 @@ class DataArray:
         buf = memoryview(container)
         self.encoded_buffer = BinaryEncodedBuffer(buf)
 
-    def get_encoded_buffer(self, encoder, compressor):
+    def get_encoded_buffer(self,
+                           encoder: str,
+                           compressor: Optional[str] = None) -> EncodedBuffer:
+        """Re-encode the underlying buffer of the current :class:`DataArray`.
+
+        :arg encoder: new encoder name.
+        :arg compressor: new compressor name.
+        """
         have_encoder = self.encoded_buffer.encoder()
         have_compressor = self.encoded_buffer.compressor()
 
@@ -435,6 +574,7 @@ class DataArray:
             if (encoder, compressor) == ("binary", None):
                 self.encoded_buffer = BinaryEncodedBuffer(raw_buf)
             elif (encoder, compressor) == ("base64", None):
+                assert isinstance(raw_buf, memoryview)
                 self.encoded_buffer = Base64EncodedBuffer(raw_buf)
             elif (encoder, compressor) == ("base64", "zlib"):
                 self.encoded_buffer = Base64ZLibEncodedBuffer(raw_buf)
@@ -449,33 +589,58 @@ class DataArray:
 
         return self.encoded_buffer
 
-    def encode(self, compressor, xml_element):
+    def encode(self, compressor: Optional[str], xml_element: "XMLElement") -> int:
+        """Encode the underlying buffer with the given compressor and add it
+        to the *xml_element*.
+
+        The re-encoding is performed using :meth:`get_encoded_buffer` and the
+        result is added to the element using
+        :meth:`EncodedBuffer.add_to_xml_element`. The encoding is always done
+        in :mod:`base64`.
+        """
+
         ebuf = self.get_encoded_buffer("base64", compressor)
         return ebuf.add_to_xml_element(xml_element)
-
-    def invoke_visitor(self, visitor):
-        return visitor.gen_data_array(self)
 
 # }}}
 
 
 # {{{ grids
 
-class UnstructuredGrid:
+class UnstructuredGrid(Visitable):
     """
+    .. automethod:: __init__
+
+    .. automethod:: vtk_extension
     .. automethod:: add_pointdata
     .. automethod:: add_celldata
     """
 
-    def __init__(self, points, cells, cell_types):
-        self.cell_count = len(cells)
+    generator_method = "gen_unstructured_grid"
 
+    def __init__(self,
+                 points: Tuple[int, DataArray],
+                 cells: Union[
+                     "np.ndarray[Any, Any]",
+                     Tuple[int, DataArray, DataArray]],
+                 cell_types: Union["np.ndarray[Any, Any]", DataArray]) -> None:
+        """
+        :arg points: a tuple containing the point count and a :class:`DataArray`
+            with the actual coordinates.
+        :arg cells: if it is only an :class:`~numpy.ndarray`, then it is assumed
+            that all the cells in the grid are uniform and have a fixed number
+            of vertices. Otherwise, a tuple of ``(ncells, connectivity, offsets)``
+            should be provided.
+        :arg cell_types: a :class:`DataArray` or :class:`~numpy.ndarray` of
+            cell types.
+        """
         self.point_count, self.points = points
         assert self.points.name == "points"
 
-        try:
+        if isinstance(cells, tuple) and len(cells) == 3:
             self.cell_count, self.cell_connectivity, self.cell_offsets = cells
-        except Exception:
+        elif isinstance(cells, np.ndarray):
+            assert not isinstance(cell_types, DataArray)
             self.cell_count = len(cell_types)
 
             if self.cell_count > 0:
@@ -487,41 +652,47 @@ class UnstructuredGrid:
 
             self.cell_connectivity = DataArray("connectivity", cells)
             self.cell_offsets = DataArray("offsets", offsets)
+        else:
+            raise TypeError(f"Unsupported 'cells' type: {type(cells)}")
 
         self.cell_types = DataArray("types", cell_types)
 
-        self.pointdata = []
-        self.celldata = []
+        self.pointdata: List[DataArray] = []
+        self.celldata: List[DataArray] = []
 
-    def copy(self):
+    def copy(self) -> "UnstructuredGrid":
         return UnstructuredGrid(
                 (self.point_count, self.points),
                 (self.cell_count, self.cell_connectivity, self.cell_offsets),
                 self.cell_types)
 
-    def vtk_extension(self):
+    def vtk_extension(self) -> str:
+        """Recommended extension for unstructured VTK grids."""
         return "vtu"
 
-    def invoke_visitor(self, visitor):
-        return visitor.gen_unstructured_grid(self)
-
-    def add_pointdata(self, data_array):
+    def add_pointdata(self, data_array: DataArray) -> None:
+        """Add point data to the grid."""
         self.pointdata.append(data_array)
 
-    def add_celldata(self, data_array):
+    def add_celldata(self, data_array: DataArray) -> None:
+        """Add cell data to the grid."""
         self.celldata.append(data_array)
 
 
-class StructuredGrid:
+class StructuredGrid(Visitable):
     """
+    .. automethod:: __init__
+
+    .. automethod:: vtk_extension
     .. automethod:: add_pointdata
     .. automethod:: add_celldata
     """
 
-    def __init__(self, mesh):
+    generator_method = "gen_structured_grid"
+
+    def __init__(self, mesh: "np.ndarray[Any, Any]") -> None:
         """
-        :arg mesh: has shape *(ndims, nx, ny, nz)*
-            (ny, nz may be omitted)
+        :arg mesh: has shape ``(ndims, nx, ny, nz)``, depending on the dimension.
         """
         self.mesh = mesh
 
@@ -535,22 +706,22 @@ class StructuredGrid:
                 "points", mesh,
                 vector_format=VF_LIST_OF_VECTORS)
 
-        self.pointdata = []
-        self.celldata = []
+        self.pointdata: List[DataArray] = []
+        self.celldata: List[DataArray] = []
 
-    def copy(self):
+    def copy(self) -> "StructuredGrid":
         return StructuredGrid(self.mesh)
 
-    def vtk_extension(self):
+    def vtk_extension(self) -> str:
+        """Recommended extension for structured VTK grids."""
         return "vts"
 
-    def invoke_visitor(self, visitor):
-        return visitor.gen_structured_grid(self)
-
-    def add_pointdata(self, data_array):
+    def add_pointdata(self, data_array: DataArray) -> None:
+        """Add point data to the grid."""
         self.pointdata.append(data_array)
 
-    def add_celldata(self, data_array):
+    def add_celldata(self, data_array: DataArray) -> None:
+        """Add cell data to the grid."""
         self.celldata.append(data_array)
 
 # }}}
@@ -558,7 +729,9 @@ class StructuredGrid:
 
 # {{{ vtk xml writers
 
-def make_vtkfile(filetype, compressor, version="0.1"):
+def make_vtkfile(filetype: str,
+                 compressor: Optional[str] = None,
+                 version: str = "0.1") -> XMLElement:
     import sys
     if sys.byteorder == "little":
         bo = "LittleEndian"
@@ -574,7 +747,13 @@ def make_vtkfile(filetype, compressor, version="0.1"):
 
 
 class XMLGenerator:
-    def __init__(self, compressor=None, vtk_file_version=None):
+    """
+    .. automethod:: __init__
+    .. automethod:: __call__
+    """
+    def __init__(self,
+                 compressor: Optional[str] = None,
+                 vtk_file_version: Optional[str] = None) -> None:
         """
         :arg vtk_file_version: a string ``"x.y"`` with the desired VTK
             XML file format version. Relevant versions are as follows:
@@ -593,7 +772,7 @@ class XMLGenerator:
 
         if compressor == "zlib":
             try:
-                import zlib  # noqa
+                import zlib  # noqa: F401
             except ImportError:
                 compressor = None
         elif compressor is None:
@@ -608,26 +787,25 @@ class XMLGenerator:
         self.vtk_file_version = vtk_file_version
         self.compressor = compressor
 
-    def __call__(self, vtkobj):
-        """Return an :class:`XMLElement`."""
+    def __call__(self, vtkobj: Visitable) -> XMLRoot:
+        """Generate an XML tree from the given *vtkobj*."""
 
         child = self.rec(vtkobj)
         vtkf = make_vtkfile(child.tag, self.compressor,
                 version=self.vtk_file_version)
         vtkf.add_child(child)
+
         return XMLRoot(vtkf)
 
-    def rec(self, vtkobj):
+    def rec(self, vtkobj: Visitable) -> XMLElement:
+        """Recursively visit all the children of *vtkobj*."""
         return vtkobj.invoke_visitor(self)
 
 
 class InlineXMLGenerator(XMLGenerator):
-    """
-    .. automethod:: __init__
-    .. automethod:: __call__
-    """
+    """An XML generator that uses inline :class:`DataArray` entries."""
 
-    def gen_unstructured_grid(self, ugrid):
+    def gen_unstructured_grid(self, ugrid: UnstructuredGrid) -> XMLElement:
         el = XMLElement("UnstructuredGrid")
         piece = XMLElement("Piece",
                 NumberOfPoints=ugrid.point_count, NumberOfCells=ugrid.cell_count)
@@ -657,7 +835,7 @@ class InlineXMLGenerator(XMLGenerator):
 
         return el
 
-    def gen_structured_grid(self, sgrid):
+    def gen_structured_grid(self, sgrid: StructuredGrid) -> XMLElement:
         extent = []
         for dim in range(3):
             extent.append(0)
@@ -688,35 +866,43 @@ class InlineXMLGenerator(XMLGenerator):
         points.add_child(self.rec(sgrid.points))
         return el
 
-    def gen_data_array(self, data):
+    def gen_data_array(self, data: DataArray) -> XMLElement:
         el = XMLElement("DataArray", type=data.type, Name=data.name,
                 NumberOfComponents=data.components, format="binary")
+
         data.encode(self.compressor, el)
         el.add_child("\n")
+
         return el
 
 
 class AppendedDataXMLGenerator(InlineXMLGenerator):
-    """
-    .. automethod:: __call__
+    """An XML generator that uses appended data for :class:`DataArray` entries.
+
+    This creates a special element called ``AppendedData`` and each data array
+    will index into it. Additional compression can be added to the appended data.
     """
 
-    def __init__(self, compressor=None, vtk_file_version=None):
-        InlineXMLGenerator.__init__(self, compressor, vtk_file_version)
+    def __init__(self, compressor: Optional[str] = None,
+                 vtk_file_version: Optional[str] = None) -> None:
+        super().__init__(compressor=compressor, vtk_file_version=vtk_file_version)
 
         self.base64_len = 0
         self.app_data = XMLElement("AppendedData", encoding="base64")
         self.app_data.add_child("_")
 
-    def __call__(self, vtkobj):
-        """Return an :class:`XMLElement`."""
+    def __call__(self, vtkobj: Visitable) -> XMLRoot:
+        xmlroot = super().__call__(vtkobj)
 
-        xmlroot = XMLGenerator.__call__(self, vtkobj)
         self.app_data.add_child("\n")
-        xmlroot.children[0].add_child(self.app_data)
+        child = xmlroot.children[0]
+
+        assert isinstance(child, XMLElement)
+        child.add_child(self.app_data)
+
         return xmlroot
 
-    def gen_data_array(self, data):
+    def gen_data_array(self, data: DataArray) -> XMLElement:
         el = XMLElement("DataArray", type=data.type, Name=data.name,
                 NumberOfComponents=data.components, format="appended",
                 offset=self.base64_len)
@@ -727,16 +913,20 @@ class AppendedDataXMLGenerator(InlineXMLGenerator):
 
 
 class ParallelXMLGenerator(XMLGenerator):
+    """An XML generator for parallel unstructured grids.
+
+    .. automethod:: __init__
     """
-    .. automethod:: __call__
-    """
 
-    def __init__(self, pathnames):
-        XMLGenerator.__init__(self, compressor=None)
+    def __init__(self, pathnames: List[Union[str, pathlib.Path]]) -> None:
+        """
+        :arg pathnames: a list of paths to indivitual VTK files containing
+            different pieces of a grid.
+        """
+        super().__init__()
+        self.pathnames = [str(p) for p in pathnames]
 
-        self.pathnames = pathnames
-
-    def gen_unstructured_grid(self, ugrid):
+    def gen_unstructured_grid(self, ugrid: UnstructuredGrid) -> XMLElement:
         el = XMLElement("PUnstructuredGrid")
 
         pointdata = XMLElement("PPointData")
@@ -759,16 +949,29 @@ class ParallelXMLGenerator(XMLGenerator):
 
         return el
 
-    def gen_data_array(self, data):
+    def gen_data_array(self, data: DataArray) -> XMLElement:
         el = XMLElement("PDataArray", type=data.type, Name=data.name,
                 NumberOfComponents=data.components)
         return el
 
 
 def write_structured_grid(
-        file_name, mesh,
-        cell_data=None, point_data=None,
-        overwrite=False):
+        file_name: Union[str, pathlib.Path],
+        mesh: "np.ndarray[Any, Any]",
+        cell_data: Optional[List[Tuple[str, "np.ndarray[Any, Any]"]]] = None,
+        point_data: Optional[List[Tuple[str, "np.ndarray[Any, Any]"]]] = None,
+        overwrite: bool = False) -> None:
+    """Write a structure grid to *filename*.
+
+    This constructs a :class:`StructuredGrid` and adds the relevant point and
+    cell data, as necessary. The data is all flattened to one dimensional
+    arrays.
+
+    :arg overwrite: if *True*, existing files are overwritten, otherwise an
+        exception is raised.
+    """
+    file_name = pathlib.Path(file_name)
+
     if cell_data is None:
         cell_data = []
 
@@ -779,7 +982,7 @@ def write_structured_grid(
 
     from pytools.obj_array import obj_array_vectorize
 
-    def do_reshape(fld):
+    def do_reshape(fld: "np.ndarray[Any, Any]") -> "np.ndarray[Any, Any]":
         return fld.T.copy().reshape(-1)
 
     for name, field in cell_data:
@@ -790,13 +993,10 @@ def write_structured_grid(
         reshaped_fld = obj_array_vectorize(do_reshape, field)
         grid.add_pointdata(DataArray(name, reshaped_fld))
 
-    import os.path
-    if os.path.exists(file_name):
-        if overwrite:
-            # nothing to do, just overwrite below
-            pass
-        else:
-            raise FileExistsError(f"output file '{file_name}' already exists")
+    if not overwrite and file_name.exists():
+        raise FileExistsError(f"Output file '{file_name}' already exists")
 
     with open(file_name, "w") as outf:
         AppendedDataXMLGenerator()(grid).write(outf)
+
+# }}}

--- a/setup.py
+++ b/setup.py
@@ -109,6 +109,7 @@ def main():
             packages=find_packages(),
             ext_package="pyvisfile.silo",
             ext_modules=ext_modules,
+            package_data={"pyvisfile": ["py.typed"]},
 
             cmdclass={"build_ext": PybindBuildExtCommand},
             zip_safe=False)

--- a/test/ref-vtk-parallel.pvtu
+++ b/test/ref-vtk-parallel.pvtu
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+<PUnstructuredGrid>
+<PPointData>
+<PDataArray type="Float64" Name="pressure" NumberOfComponents="1"/>
+<PDataArray type="Float64" Name="velocity" NumberOfComponents="3"/>
+</PPointData>
+<PPoints>
+<PDataArray type="Float64" Name="points" NumberOfComponents="3"/>
+</PPoints>
+<PCells>
+<PDataArray type="UInt32" Name="connectivity" NumberOfComponents="1"/>
+<PDataArray type="UInt32" Name="offsets" NumberOfComponents="1"/>
+<PDataArray type="UInt8" Name="types" NumberOfComponents="1"/>
+</PCells>
+<Piece Source="vtk-parallel-piece-0.vtu"/>
+<Piece Source="vtk-parallel-piece-1.vtu"/>
+<Piece Source="vtk-parallel-piece-2.vtu"/>
+<Piece Source="vtk-parallel-piece-3.vtu"/>
+<Piece Source="vtk-parallel-piece-4.vtu"/>
+</PUnstructuredGrid>
+</VTKFile>


### PR DESCRIPTION
In my quest to add support for that `HyperTreeGrid` thing, I started slowing adding typing to the `vtk` module as well. It should be fairly complete now, but it has some actual changes in there to make `mypy` happy:
* Moved the `copy` from `XMLElementBase` to `XMLElement` (doesn't seem to be used anyway).
* Made the `EncodedBuffer` an `ABC` (it looked like it wanted to be a `Protocol`, but this seemed easier)
* Added a base class `Visitable` for `DataArray`, `UnstructuredGrid` and `StructuredGrid` to type "things that can generate XML".

The commits should be pretty independent, so could look at them separately. There may be some fishy things in there, but `mypy --strict` is happy at least!

