### PR TITLE
Update `shape` when redefining `container` in VTK code

### DIFF
--- a/pyvisfile/vtk/__init__.py
+++ b/pyvisfile/vtk/__init__.py
@@ -580,6 +580,7 @@ class DataArray(Visitable):
                         np.zeros((shape[0], vector_padding-shape[1]),
                                  dtype=container.dtype))
                     ), order="C")
+                shape = container.shape
             self.components = shape[1]
         else:
             self.components = 1


### PR DESCRIPTION
Should fix the pytest failures in [meshmode CI](https://github.com/inducer/meshmode/actions/runs/22813415943) (I tested locally to confirm).

Not sure what the basedpyright errors are about.